### PR TITLE
Set max listeners to the number of canvases

### DIFF
--- a/src/canvasObject.js
+++ b/src/canvasObject.js
@@ -63,7 +63,6 @@ CanvasObject.prototype = {
         }
       }
     };
-
     this.dispatcher.on('image-resource-tile-source-opened', onTileDrawn);
     image.openTileSource();
   },

--- a/src/main.js
+++ b/src/main.js
@@ -53,7 +53,8 @@ var manifestor = function(options) {
     _dispatcher.on(event, handler);
   }
 
-  _dispatcher.setMaxListeners(canvases.length + 1);
+  // Each canvas will listen when it opens tile sources, and clients consuming this code may attach some as well.
+  _dispatcher.setMaxListeners(canvases.length + 30);
 
   var overlays = $('<div class="overlaysContainer">').css(
     {'width': '100%',

--- a/src/main.js
+++ b/src/main.js
@@ -53,6 +53,8 @@ var manifestor = function(options) {
     _dispatcher.on(event, handler);
   }
 
+  _dispatcher.setMaxListeners(canvases.length + 1);
+
   var overlays = $('<div class="overlaysContainer">').css(
     {'width': '100%',
      'height': '100%',


### PR DESCRIPTION
This seems like a lot (and the Node EventEmitter's default maximum is 10), but it's currently possible for all of the canvases to be opening their main tilesources concurrently, and each canvas needs a listener.

This will silence the warning that @aeschylus was seeing- I don't think it's the cause of the memory problems, though.
