### PR TITLE
Force legacy thumbnails

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -11,7 +11,7 @@ var App = {
     this.$images.empty();
 
     $('<option>')
-      .val('http://dms-data.stanford.edu/data/manifests/BnF/jr903ng8662/manifest.json')
+      .val('http://manifests.ydc2.yale.edu/manifest/Osbornfa1v2.json')
       .text('Default')
       .appendTo(this.$manifestPicker);
 

--- a/src/thumbnailFactory.js
+++ b/src/thumbnailFactory.js
@@ -4,7 +4,7 @@ var ImageResource = require('./ImageResource');
 
 var _getThumbUrl = function(resource, width) {
   if(resource.service) {
-    return resource.service['@id'] + '/full/' + Math.ceil(width / 4) + ',/0/default.jpg';
+    return resource.service['@id'] + '/full/' + Math.ceil(width) + ',/0/default.jpg';
   } else if(resource.default) {
     return _getThumbUrl(resource.default, width);
   } else {
@@ -12,12 +12,23 @@ var _getThumbUrl = function(resource, width) {
   }
 };
 
-var _makeThumbnailConfig = function(url, parent) {
+var _getThumbLevel = function(canvas, divisor) {
+  return {
+    url: _getThumbUrl(canvas.images[0].resource, canvas.width / divisor),
+    height: canvas.height / divisor,
+    width: canvas.width / divisor,
+  }
+};
+
+var _makeThumbnailConfig = function(canvas, parent) {
   return {
     tileSource: {
-      type: 'image',
-      url: url,
-      buildPyramid: 'false',
+      type: 'legacy-image-pyramid',
+      levels: [
+        _getThumbLevel(canvas, 4),
+        _getThumbLevel(canvas, 8),
+        _getThumbLevel(canvas, 16)
+      ]
     },
     parent: parent,
     imageType: 'thumbnail',
@@ -36,8 +47,12 @@ var ThumbnailFactory = function(canvas, parent) {
   // If there is no thumbnail and only one image in this canvas, there's no reason to make a thumbnail for it-
   // the canvasobject will fall back to opening the main tilesource in the absence of a thumbnail.
   if(canvas.images && canvas.images.length > 1) {
-    var config = _makeThumbnailConfig(_getThumbUrl(canvas.images[0].resource, canvas.width), parent);
+    var config = _makeThumbnailConfig(canvas, parent);
     return new ImageResource(config);
+  }
+
+  if(canvas.images.length == 1) {
+    console.log("Only one image");
   }
 };
 

--- a/src/thumbnailFactory.js
+++ b/src/thumbnailFactory.js
@@ -16,10 +16,10 @@ var _makeThumbnailConfig = function(url, parent) {
   return {
     tileSource: {
       type: 'image',
-      url: url
+      url: url,
+      buildPyramid: 'false',
     },
     parent: parent,
-    buildPyramid: 'false',
     imageType: 'thumbnail',
     dynammic: false
   };

--- a/src/thumbnailFactory.js
+++ b/src/thumbnailFactory.js
@@ -3,31 +3,31 @@
 var ImageResource = require('./ImageResource');
 
 var _getThumbUrl = function(resource, width) {
-  if(resource.service) {
-    return resource.service['@id'] + '/full/' + Math.ceil(width) + ',/0/default.jpg';
-  } else if(resource.default) {
-    return _getThumbUrl(resource.default, width);
+  if(resource.default) {
+    return resource.default.id;
   } else {
     return resource['@id'];
   }
 };
 
-var _getThumbLevel = function(canvas, divisor) {
+var _getThumbLevel = function(resource) {
+  if(resource.default) {
+    return _getThumbLevel(resource.default);
+  }
+
   return {
-    url: _getThumbUrl(canvas.images[0].resource, canvas.width / divisor),
-    height: canvas.height / divisor,
-    width: canvas.width / divisor,
+    url: resource['@id'],
+    height: resource.height,
+    width: resource.width,
   }
 };
 
-var _makeThumbnailConfig = function(canvas, parent) {
+var _makeThumbnailConfig = function(resource, parent) {
   return {
     tileSource: {
       type: 'legacy-image-pyramid',
       levels: [
-        _getThumbLevel(canvas, 4),
-        _getThumbLevel(canvas, 8),
-        _getThumbLevel(canvas, 16)
+        _getThumbLevel(resource),
       ]
     },
     parent: parent,
@@ -44,15 +44,9 @@ var ThumbnailFactory = function(canvas, parent) {
 
   // If the canvas has no thumbnail object, we try to fall back to using an image from it.
   // If the canvas has no images and no thumbnail, we can't do anything, so we don't bother.
-  // If there is no thumbnail and only one image in this canvas, there's no reason to make a thumbnail for it-
-  // the canvasobject will fall back to opening the main tilesource in the absence of a thumbnail.
-  if(canvas.images && canvas.images.length > 1) {
-    var config = _makeThumbnailConfig(canvas, parent);
+  if(canvas.images) {
+    var config = _makeThumbnailConfig(canvas.images[0].resource, parent);
     return new ImageResource(config);
-  }
-
-  if(canvas.images.length == 1) {
-    console.log("Only one image");
   }
 };
 


### PR DESCRIPTION
This is an attempt to address #111 . Here, I always use a LegacyTileSource, and always create a thumbnail, regardless of how many images a canvas has.

This means that I'm not requesting all of the info.json files; rather, OpenSeadragon is smart enough to lazy load the images it wants to display.
