### PR TITLE
Sometimes a resource id is not a url. Handle that.

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -11,7 +11,7 @@ var App = {
     this.$images.empty();
 
     $('<option>')
-      .val('http://manifests.ydc2.yale.edu/manifest/Osbornfa1v2.json')
+      .val('http://dms-data.stanford.edu/data/manifests/BnF/jr903ng8662/manifest.json')
       .text('Default')
       .appendTo(this.$manifestPicker);
 

--- a/src/thumbnailFactory.js
+++ b/src/thumbnailFactory.js
@@ -20,16 +20,19 @@ var _getResourceFormat = function(mimeType) {
   }
 };
 
-var _getThumbUrl = function(resource, width) {
-  if(resource.default) {
-    return resource.default.id;
-  } else {
-    var id = resource['@id'];
-    if(!id.toLowerCase().match(/^.*\.(png|jpg|jpeg|gif)$/)) { // it is still a service URL
-      var format = _getResourceFormat(resource.format);
-      return resource.service['@id'] + '/full/' + Math.ceil(resource.width / 4) + ',/0/default.' + format;
-    }
-    return id;
+var _getThumbUrl = function(resource) {
+
+  var _buildResourceSize = function() {
+    return "/full/" + Math.ceil(resource.width / 4) + ",/";
+  }
+
+  var id = resource['@id'];
+  if(!id.toLowerCase().match(/^.*\.(png|jpg|jpeg|gif)$/)) { // it is still a service URL
+    var format = _getResourceFormat(resource.format);
+    return resource.service['@id'] + _buildResourceSize() + '0/default.' + format;
+  }
+  else { // we still don't want the full size
+    return id.replace("/full/full/", _buildResourceSize());
   }
 };
 

--- a/src/thumbnailFactory.js
+++ b/src/thumbnailFactory.js
@@ -1,12 +1,35 @@
 'use strict';
 
 var ImageResource = require('./ImageResource');
+var imageFormatError = "Unsupported image format for LegacyTileSource.";
+
+var _getResourceFormat = function(mimeType) {
+  switch(mimeType) {
+    case('image/jpeg'):
+      return 'jpg';
+      break;
+    case('image/png'):
+      return 'png';
+      break;
+    case('image/gif'):
+      return 'gif';
+      break;
+    default:
+      throw(imageFormatError)
+      break;
+  }
+};
 
 var _getThumbUrl = function(resource, width) {
   if(resource.default) {
     return resource.default.id;
   } else {
-    return resource['@id'];
+    var id = resource['@id'];
+    if(!id.toLowerCase().match(/^.*\.(png|jpg|jpeg|gif)$/)) { // it is still a service URL
+      var format = _getResourceFormat(resource.format);
+      return resource.service['@id'] + '/full/' + Math.ceil(resource.width / 4) + ',/0/default.' + format;
+    }
+    return id;
   }
 };
 
@@ -16,7 +39,7 @@ var _getThumbLevel = function(resource) {
   }
 
   return {
-    url: resource['@id'],
+    url: _getThumbUrl(resource),
     height: resource.height,
     width: resource.width,
   }
@@ -45,8 +68,17 @@ var ThumbnailFactory = function(canvas, parent) {
   // If the canvas has no thumbnail object, we try to fall back to using an image from it.
   // If the canvas has no images and no thumbnail, we can't do anything, so we don't bother.
   if(canvas.images) {
-    var config = _makeThumbnailConfig(canvas.images[0].resource, parent);
-    return new ImageResource(config);
+    try {
+      var config = _makeThumbnailConfig(canvas.images[0].resource, parent);
+      return new ImageResource(config);
+    } catch (error){
+      // If we can't use LegacyTileSource to build the thumbnail, don't build a thumbnail.
+      if(error == imageFormatError) {
+        return;
+      } else {
+        throw (error);
+      }
+    }
   }
 };
 


### PR DESCRIPTION
While testing my fix for #97 I discovered that my work on #112 was incomplete. I hadn't taken into account the fact that a resource id might not be a URL that LegacyTileSource can use.
