### PR TITLE
Remove thumbnail when any image is selected

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -195,6 +195,7 @@ var App = {
                 if(image.status === 'shown') {
                   image.show();
                 } else {
+                  self.selectedCanvas.removeThumbnail();
                   image.openTileSource();
                 }
               } else {

--- a/src/canvasObject.js
+++ b/src/canvasObject.js
@@ -41,6 +41,14 @@ var CanvasObject = function(config) {
 };
 
 CanvasObject.prototype = {
+  removeThumbnail: function() {
+    if(this.thumbnail){
+      this.thumbnail.removeFromCanvas();
+      this.thumbnail.destroy();
+      delete this.thumbnail;
+    }
+  },
+
   openMainTileSource: function(imageIndex) {
     if(this.images.length === 0) {
       return; // there are no images to open
@@ -55,12 +63,7 @@ CanvasObject.prototype = {
       if(event.detail.tileSource === image.tileSource) {
         self.dispatcher.removeListener('image-resource-tile-source-opened', onTileDrawn);
         image.fade(1);
-
-        if(self.thumbnail){
-          self.thumbnail.removeFromCanvas();
-          self.thumbnail.destroy();
-          delete self.thumbnail;
-        }
+        self.removeThumbnail();
       }
     };
     this.dispatcher.on('image-resource-tile-source-opened', onTileDrawn);


### PR DESCRIPTION
This is a way of addressing https://github.com/sul-dlss/iiifManifestLayouts/issues/118

The behavior there is a result of the fact that the thumbnail was only removed when canvas.openMainTileSource() was called. That, in turn, was only ever called when a canvas was clicked (because semantic zoom isn't in yet).

That means that there was a set of checkboxes next to the image, which users could click on in order to load full-fidelity images, but the thumbnail wouldn't go away, because the checkboxes themselves were wired up directly to the image objects. In this way, a user could cause the main tile source to get opened, without canvas.openMainTileSource() ever having been called.

The change is to remove the thumbnail when one of those boxes is checked and an image is opened.
