### PR TITLE
Refactor main.js

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -447,10 +447,11 @@ var manifestor = function(options) {
       .style('-webkit-transform', transform);
   }
 
-  function synchronisePan(width, height) {
+  function setViewerBoundsFromState(animate) {
     var rState = renderState.getState();
-    var viewBounds = new OpenSeadragon.Rect(rState.overviewLeft, rState.overviewTop + rState.lastScrollPosition, width, height);
-    viewer.viewport.fitBounds(viewBounds, true);
+    var vState = viewerState.getState();
+    var viewBounds = new OpenSeadragon.Rect(rState.overviewLeft, rState.overviewTop + rState.lastScrollPosition, vState.width, vState.height);
+    viewer.viewport.fitBounds(viewBounds, animate);
   }
 
   function applyConstraints() {
@@ -697,12 +698,9 @@ var manifestor = function(options) {
   }
 
   function scrollHandler(event) {
-    var currentState = viewerState.getState();
-    if (currentState.perspective === 'overview' && renderState.getState().zooming === false) {
-      var width = currentState.width;
-      var height = currentState.height;
+    if (viewerState.getState().perspective === 'overview' && renderState.getState().zooming === false) {
       renderState.setState({ lastScrollPosition: $(this).scrollTop() });
-      synchronisePan(width, height);
+      setViewerBoundsFromState(true);
     }
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ var manifestor = function(options) {
       stateUpdateCallback = options.stateUpdateCallback,
       viewerState,
       _canvasObjects,
-      _zooming = false, // todo: store this in viewerState
+      _zooming = false, // todo: store this in viewerState?
       _constraintBounds = {x:0, y:0, width:container.width(), height:container.height()},
       _inZoomConstraints,
       _lastScrollPosition = 0,
@@ -34,7 +34,6 @@ var manifestor = function(options) {
       _destroyed = false,
       _overviewLeft = 0,
       _overviewTop = 0,
-      _previousState = {},
       _transitionZoomLevel = 0.01;
 
   function getViewingDirection() {
@@ -115,29 +114,9 @@ var manifestor = function(options) {
     viewerState.setState(state);
   }
 
-  function render() {
+  function render(differences) {
     var userState = viewerState.getState();
-
-    // Figure out what's changed
-    var differences = [];
-    var key;
-    for (key in _previousState) {
-      if (_previousState.hasOwnProperty(key) && (!userState.hasOwnProperty(key) ||
-          _previousState[key] !== userState[key])) {
-        differences.push(key);
-      }
-    }
-
-    for (key in userState) {
-      if (userState.hasOwnProperty(key) && !_previousState.hasOwnProperty(key)) {
-        differences.push(key);
-      }
-    }
-
-    var previousPerspective = '';
-    if (userState.perspective !== _previousState.perspective) {
-      previousPerspective = _previousState.perspective;
-    }
+    var previousPerspective = differences.perspective || userState.perspective;
 
     // console.log('[render] state differences', differences);
 
@@ -195,13 +174,11 @@ var manifestor = function(options) {
         doRender('overview', true);
       });
     } else {
-      var animateRender = (userState.selectedCanvas !== _previousState.selectedCanvas ||
-        userState.viewingMode !== _previousState.viewingMode);
-
+      var animateRender = ('selectedCanvas' in differences || 'viewingMode' in differences);
       frames = doRender(userState.perspective, animateRender);
     }
 
-    var animateViewport = previousPerspective || userState.selectedCanvas !== _previousState.selectedCanvas;
+    var animateViewport = ('perspective' in differences || 'selectedCanvas' in differences);
 
     var viewBounds;
     if (userState.perspective === 'detail') {
@@ -231,15 +208,6 @@ var manifestor = function(options) {
         _zooming = false;
         setScrollElementEvents();
       }, 1200);
-    }
-
-    // Copy state
-    _previousState = {};
-
-    for (key in userState) {
-      if (userState.hasOwnProperty(key)) {
-        _previousState[key] = userState[key];
-      }
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -198,18 +198,13 @@ var manifestor = function(options) {
     } else {
       renderState.setState({
         overviewLeft: frames[0].x - (layout.viewport.width * layout.viewport.padding.left / 100),
-        overviewTop: frames[0].y - (layout.viewport.height * layout.viewport.padding.top / 100)
+        overviewTop: frames[0].y - (layout.viewport.height * layout.viewport.padding.top / 100),
+        zooming: true
       });
 
-      var vState = viewerState.getState();
-      var rState = renderState.getState();
-      viewBounds = new OpenSeadragon.Rect(rState.overviewLeft, rState.overviewTop + rState.lastScrollPosition,
-        vState.width, vState.height);
-
-      renderState.setState({zooming: true});
       disableZoomAndPan();
       setScrollElementEvents();
-      viewer.viewport.fitBounds(viewBounds, !animateViewport);
+      setViewerBoundsFromState(!animateViewport);
 
       setTimeout(function(){
         renderState.setState({zooming: false});

--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ var manifestor = function(options) {
   scrollContainer.append(overlays);
   initOSD();
   viewerState = viewerState || new ViewerState({
-    updateCallback: render,
+    updateCallbacks: [render, stateUpdateCallback],
     selectedCanvas: selectedCanvas, // @id of the canvas:
     perspective: initialPerspective, // can be 'overview' or 'detail'
     viewingMode: initialViewingMode, // manifest derived or user specified (iiif viewingHint)

--- a/src/main.js
+++ b/src/main.js
@@ -30,8 +30,6 @@ var manifestor = function(options) {
       _canvasObjects,
       _dispatcher = new events.EventEmitter(),
       _destroyed = false,
-      _overviewLeft = 0, // for render state
-      _overviewTop = 0, // for render state
       _transitionZoomLevel = 0.01;
 
   function getViewingDirection() {
@@ -97,7 +95,9 @@ var manifestor = function(options) {
     zooming: false,
     constraintBounds: {x:0, y:0, width:container.width(), height:container.height()},
     inZoomConstraints: false,
-    lastScrollPosition: $(this).scrollTop()
+    lastScrollPosition: $(this).scrollTop(),
+    overviewLeft: 0,
+    overviewTop: 0
   })
   buildCanvasStates(canvases, viewer);
 
@@ -196,12 +196,15 @@ var manifestor = function(options) {
       viewer.viewport.fitBounds(osdBounds, !animateViewport);
       enableZoomAndPan();
     } else {
-      _overviewLeft = frames[0].x - (layout.viewport.width * layout.viewport.padding.left / 100);
-      _overviewTop = frames[0].y - (layout.viewport.height * layout.viewport.padding.top / 100);
+      renderState.setState({
+        overviewLeft: frames[0].x - (layout.viewport.width * layout.viewport.padding.left / 100),
+        overviewTop: frames[0].y - (layout.viewport.height * layout.viewport.padding.top / 100)
+      });
 
-      var state = viewerState.getState();
-      viewBounds = new OpenSeadragon.Rect(_overviewLeft, _overviewTop + renderState.getState().lastScrollPosition,
-        state.width, state.height);
+      var vState = viewerState.getState();
+      var rState = renderState.getState();
+      viewBounds = new OpenSeadragon.Rect(rState.overviewLeft, rState.overviewTop + rState.lastScrollPosition,
+        vState.width, vState.height);
 
       renderState.setState({zooming: true});
       disableZoomAndPan();
@@ -445,7 +448,8 @@ var manifestor = function(options) {
   }
 
   function synchronisePan(width, height) {
-    var viewBounds = new OpenSeadragon.Rect(_overviewLeft, _overviewTop + renderState.getState().lastScrollPosition, width, height);
+    var rState = renderState.getState();
+    var viewBounds = new OpenSeadragon.Rect(rState.overviewLeft, rState.overviewTop + rState.lastScrollPosition, width, height);
     viewer.viewport.fitBounds(viewBounds, true);
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -27,13 +27,13 @@ var manifestor = function(options) {
       viewerState,
       _canvasObjects,
       _zooming = false, // todo: store this in some kind of render state
-      _constraintBounds = {x:0, y:0, width:container.width(), height:container.height()},
-      _inZoomConstraints,
-      _lastScrollPosition = 0,
+      _constraintBounds = {x:0, y:0, width:container.width(), height:container.height()}, // for render state
+      _inZoomConstraints, // for render state
+      _lastScrollPosition = 0, // for render state
       _dispatcher = new events.EventEmitter(),
       _destroyed = false,
-      _overviewLeft = 0,
-      _overviewTop = 0,
+      _overviewLeft = 0, // for render state
+      _overviewTop = 0, // for render state
       _transitionZoomLevel = 0.01;
 
   function getViewingDirection() {

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,6 @@ var manifestor = function(options) {
       viewerState,
       renderState,
       _canvasObjects,
-      _lastScrollPosition = 0, // for render state
       _dispatcher = new events.EventEmitter(),
       _destroyed = false,
       _overviewLeft = 0, // for render state
@@ -97,7 +96,8 @@ var manifestor = function(options) {
   renderState = renderState || new RenderState({
     zooming: false,
     constraintBounds: {x:0, y:0, width:container.width(), height:container.height()},
-    inZoomConstraints: false
+    inZoomConstraints: false,
+    lastScrollPosition: $(this).scrollTop()
   })
   buildCanvasStates(canvases, viewer);
 
@@ -200,7 +200,7 @@ var manifestor = function(options) {
       _overviewTop = frames[0].y - (layout.viewport.height * layout.viewport.padding.top / 100);
 
       var state = viewerState.getState();
-      viewBounds = new OpenSeadragon.Rect(_overviewLeft, _overviewTop + _lastScrollPosition,
+      viewBounds = new OpenSeadragon.Rect(_overviewLeft, _overviewTop + renderState.getState().lastScrollPosition,
         state.width, state.height);
 
       renderState.setState({zooming: true});
@@ -433,7 +433,7 @@ var manifestor = function(options) {
     var viewerHeight = viewer.container.clientHeight;
     var center = viewer.viewport.getCenter(true);
     var p = center.minus(new OpenSeadragon.Point(viewerWidth / 2, viewerHeight / 2))
-          .minus(new OpenSeadragon.Point(0, _lastScrollPosition));
+          .minus(new OpenSeadragon.Point(0, renderState.getState().lastScrollPosition));
     var zoom = viewer.viewport.getZoom(true);
     var scale = viewerWidth * zoom;
 
@@ -444,8 +444,8 @@ var manifestor = function(options) {
       .style('-webkit-transform', transform);
   }
 
-  function synchronisePan(panTop, width, height) {
-    var viewBounds = new OpenSeadragon.Rect(_overviewLeft, _overviewTop + _lastScrollPosition, width, height);
+  function synchronisePan(width, height) {
+    var viewBounds = new OpenSeadragon.Rect(_overviewLeft, _overviewTop + renderState.getState().lastScrollPosition, width, height);
     viewer.viewport.fitBounds(viewBounds, true);
   }
 
@@ -697,8 +697,8 @@ var manifestor = function(options) {
     if (currentState.perspective === 'overview' && renderState.getState().zooming === false) {
       var width = currentState.width;
       var height = currentState.height;
-      _lastScrollPosition = $(this).scrollTop();
-      synchronisePan(_lastScrollPosition, width, height);
+      renderState.setState({ lastScrollPosition: $(this).scrollTop() });
+      synchronisePan(width, height);
     }
   };
 

--- a/src/main.js
+++ b/src/main.js
@@ -26,7 +26,7 @@ var manifestor = function(options) {
       stateUpdateCallback = options.stateUpdateCallback,
       viewerState,
       _canvasObjects,
-      _zooming = false, // todo: store this in viewerState?
+      _zooming = false, // todo: store this in some kind of render state
       _constraintBounds = {x:0, y:0, width:container.width(), height:container.height()},
       _inZoomConstraints,
       _lastScrollPosition = 0,
@@ -597,10 +597,11 @@ var manifestor = function(options) {
 
     // state.constraintBounds = bounds;
 
-    // todo: store this in viewerState
+    // DO NOT store this in viewerState, as updating viewerState causes render() to be called,
+    // and this function is only called from deep within render(). Havoc is caused.
+    // Put it in whatever state object _zooming goes in.
     _constraintBounds = bounds;
 
-    // viewerState(state);
   }
 
   function _isValidCanvasIndex(index) {

--- a/src/osdUtils.js
+++ b/src/osdUtils.js
@@ -1,0 +1,146 @@
+'use strict';
+
+require('openseadragon');
+
+var OSDUtils = function() {
+}
+
+OSDUtils.prototype = {
+  initOSD: function(osdContainer) {
+    this.viewer = OpenSeadragon({
+      element: osdContainer[0],
+      showNavigationControl: false,
+      preserveViewport: true
+    });
+
+    return this.viewer;
+  },
+
+  addOSDHandlers: function(viewerState, renderState) {
+    this.viewerState = viewerState;
+    this.renderState = renderState;
+    var self = this;
+
+    // Open the main tile source when we reach the specified zoom level on it
+    var _semanticZoom = function(zoom, center) {
+      var _transitionZoomLevel = 0.01;
+      var state = self.viewerState.getState();
+      if(zoom >= _transitionZoomLevel) {
+        for(var key in state.canvasObjects) {
+          if(state.canvasObjects[key].containsPoint(center)) {
+            state.canvasObjects[key].openMainTileSource();
+          }
+        }
+      }
+    };
+
+
+    var _applyConstraints = function() {
+      var state = self.renderState.getState();
+      var constraintBounds = new OpenSeadragon.Rect(
+        state.constraintBounds.x,
+        state.constraintBounds.y,
+        state.constraintBounds.width,
+        state.constraintBounds.height
+      );
+
+      if (constraintBounds && !state.inZoomConstraints) {
+        var changed = false;
+        var currentBounds = self.viewer.viewport.getBounds();
+
+        if (currentBounds.x < constraintBounds.x - 0.00001) {
+          currentBounds.x = constraintBounds.x;
+          changed = true;
+        }
+
+        if (currentBounds.y < constraintBounds.y - 0.00001) {
+          currentBounds.y = constraintBounds.y;
+          changed = true;
+        }
+
+        if (currentBounds.width > constraintBounds.width + 0.00001) {
+          currentBounds.width = constraintBounds.width;
+          changed = true;
+        }
+
+        if (currentBounds.height > constraintBounds.height + 0.00001) {
+          currentBounds.height = constraintBounds.height;
+          changed = true;
+        }
+
+        if (currentBounds.x + currentBounds.width > constraintBounds.x + constraintBounds.width + 0.00001) {
+          currentBounds.x = (constraintBounds.x + constraintBounds.width) - currentBounds.width;
+          changed = true;
+        }
+
+        if (currentBounds.y + currentBounds.height > constraintBounds.y + constraintBounds.height + 0.00001) {
+          currentBounds.y = (constraintBounds.y + constraintBounds.height) - currentBounds.height;
+          changed = true;
+        }
+
+        if (changed) {
+          self.renderState.setState({ inZoomConstraints: true });
+          self.viewer.viewport.fitBounds(currentBounds);
+          self.renderState.setState({ inZoomConstraints: false });
+        }
+      }
+
+      // var zoom = viewer.viewport.getZoom();
+      // var maxZoom = 2;
+
+      // var zoomPoint = viewer.viewport.zoomPoint || viewer.viewport.getCenter();
+      // var info = this.hitTest(zoomPoint);
+      // if (info) {
+        // var page = this.pages[info.index];
+        // var tiledImage = page.hitTest(zoomPoint);
+        // if (tiledImage) {
+        //   maxZoom = this.viewer.maxZoomLevel;
+        //   if (!maxZoom) {
+        //     var imageWidth = tiledImage.getContentSize().x;
+        //     var viewerWidth = this.$el.width();
+        //     maxZoom = imageWidth * this.viewer.maxZoomPixelRatio / viewerWidth;
+        //     maxZoom /= tiledImage.getBounds().width;
+        //   }
+        // }
+      // }
+
+      // if (zoom > maxZoom) {
+      //   this.viewer.viewport.zoomSpring.target.value = maxZoom;
+      // }
+    }
+    console.log(this.viewerState);
+    this.viewer.addHandler('zoom', function(event) {
+      if (self.viewerState.getState().perspective === 'detail') {
+        _applyConstraints();
+      }
+      var center = self.viewer.viewport.getBounds().getCenter();
+      _semanticZoom(event.zoom, center);
+    });
+
+    this.viewer.addHandler('pan', function(event) {
+      if (self.viewerState.getState().perspective === 'detail') {
+        _applyConstraints();
+      }
+      var zoom = self.viewer.viewport.getZoom();
+      _semanticZoom(zoom, event.center);
+    });
+
+    this.viewer.addHandler('canvas-click', function(event) {
+      var hitCanvases = [];
+      var clickPosition = self.viewer.viewport.pointFromPixel(event.position);
+      var state = viewerState.getState();
+      for(var key in state.canvasObjects) {
+        if(state.canvasObjects[key].containsPoint(clickPosition)){
+          hitCanvases.push(state.canvasObjects[key]);
+        }
+      }
+      if(event.quick && hitCanvases[0]) {
+        var bounds = hitCanvases[0].getBounds();
+        self.viewer.viewport.fitBounds(bounds);
+        hitCanvases[0].openMainTileSource();
+      }
+    });
+  }
+};
+
+module.exports = OSDUtils;

--- a/src/renderState.js
+++ b/src/renderState.js
@@ -2,6 +2,7 @@ var renderState = function(config) {
   this.state = {
     zooming: config.zooming,
     constraintBounds: config.constraintBounds,
+    inZoomConstraints: config.inZoomConstraints
   };
 };
 

--- a/src/renderState.js
+++ b/src/renderState.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var renderState = function(config) {
   this.state = {
     zooming: config.zooming,

--- a/src/renderState.js
+++ b/src/renderState.js
@@ -1,0 +1,23 @@
+var renderState = function(config) {
+  this.state = {
+    zooming: config.zooming,
+  };
+};
+
+renderState.prototype = {
+  getState: function() {
+    return this.state;
+  },
+
+  setState: function(newState) {
+    for(var key in newState) {
+      if(newState.hasOwnProperty(key)) {
+        if(this.state[key] !== newState[key]) {
+          this.state[key] = newState[key];
+        }
+      }
+    }
+  }
+};
+
+module.exports = renderState;

--- a/src/renderState.js
+++ b/src/renderState.js
@@ -1,6 +1,7 @@
 var renderState = function(config) {
   this.state = {
     zooming: config.zooming,
+    constraintBounds: config.constraintBounds,
   };
 };
 

--- a/src/renderState.js
+++ b/src/renderState.js
@@ -2,7 +2,8 @@ var renderState = function(config) {
   this.state = {
     zooming: config.zooming,
     constraintBounds: config.constraintBounds,
-    inZoomConstraints: config.inZoomConstraints
+    inZoomConstraints: config.inZoomConstraints,
+    lastScrollPosition: config.lastScrollPosition
   };
 };
 

--- a/src/renderState.js
+++ b/src/renderState.js
@@ -3,7 +3,9 @@ var renderState = function(config) {
     zooming: config.zooming,
     constraintBounds: config.constraintBounds,
     inZoomConstraints: config.inZoomConstraints,
-    lastScrollPosition: config.lastScrollPosition
+    lastScrollPosition: config.lastScrollPosition,
+    overviewLeft: config.overviewLeft,
+    overviewTop: config.overviewTop
   };
 };
 

--- a/src/viewerState.js
+++ b/src/viewerState.js
@@ -2,6 +2,7 @@ var viewerState = function(config) {
   this.updateCallbacks = config.updateCallbacks;
 
   this.state = {
+    canvasObjects: config.canvasObjects,
     selectedCanvas: config.selectedCanvas, // @id of the canvas:
     perspective: config.perspective, // can be 'overview' or 'detail'
     viewingMode: config.viewingMode, // manifest derived or user specified (iiif viewingHint)
@@ -33,6 +34,10 @@ viewerState.prototype = {
         }
       });
     }
+  },
+
+  selectedCanvasObject: function() {
+    return this.state.canvasObjects[this.state.selectedCanvas];
   }
 };
 

--- a/src/viewerState.js
+++ b/src/viewerState.js
@@ -1,0 +1,29 @@
+var viewerState = function(config) {
+  this.updateCallback = config.updateCallback;
+
+  this.state = {
+    selectedCanvas: config.selectedCanvas, // @id of the canvas:
+    perspective: config.perspective, // can be 'overview' or 'detail'
+    viewingMode: config.viewingMode, // manifest derived or user specified (iiif viewingHint)
+    viewingDirection: config.viewingDirection, // manifest derived or user specified (iiif viewingHint)
+    width: config.width,
+    height: config.height
+  };
+};
+
+viewerState.prototype = {
+  getState: function() {
+    return this.state;
+  },
+
+  setState: function(newState) {
+    for(var key in newState) {
+      this.state[key] = newState[key];
+    }
+    if(this.updateCallback) {
+      this.updateCallback();
+    }
+  }
+};
+
+module.exports = viewerState;

--- a/src/viewerState.js
+++ b/src/viewerState.js
@@ -17,13 +17,17 @@ viewerState.prototype = {
   },
 
   setState: function(newState) {
+    var differences = {};
     for(var key in newState) {
       if(newState.hasOwnProperty(key)) {
-        this.state[key] = newState[key];
+        if(this.state[key] !== newState[key]) {
+          differences[key] = this.state[key];
+          this.state[key] = newState[key];
+        }
       }
     }
     if(this.updateCallback) {
-      this.updateCallback();
+      this.updateCallback(differences);
     }
   }
 };

--- a/src/viewerState.js
+++ b/src/viewerState.js
@@ -18,7 +18,9 @@ viewerState.prototype = {
 
   setState: function(newState) {
     for(var key in newState) {
-      this.state[key] = newState[key];
+      if(newState.hasOwnProperty(key)) {
+        this.state[key] = newState[key];
+      }
     }
     if(this.updateCallback) {
       this.updateCallback();

--- a/src/viewerState.js
+++ b/src/viewerState.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var viewerState = function(config) {
   this.updateCallbacks = config.updateCallbacks;
 

--- a/src/viewerState.js
+++ b/src/viewerState.js
@@ -1,5 +1,5 @@
 var viewerState = function(config) {
-  this.updateCallback = config.updateCallback;
+  this.updateCallbacks = config.updateCallbacks;
 
   this.state = {
     selectedCanvas: config.selectedCanvas, // @id of the canvas:
@@ -26,8 +26,12 @@ viewerState.prototype = {
         }
       }
     }
-    if(this.updateCallback) {
-      this.updateCallback(differences);
+    if(this.updateCallbacks) {
+      this.updateCallbacks.forEach(function(callback) {
+        if(callback) {
+          callback(differences);
+        }
+      });
     }
   }
 };


### PR DESCRIPTION
This represents 4 hours of time-boxed refactoring. Here's what it includes:
- Make an object to represent the state of the whole viewer/manifestor itself (viewerState). Maybe I should call it manifestorState, so it isn't to be confused with the OSD viewer?
- Make an object to represent render state. This was necessary because changing viewerState causes a render to happen- but there are state variables we want to keep track of for rendering. In order to avoid infinite updating/rendering, I moved those out into renderState.

Since I had those state objects, and I made them singletons,  I could start moving other code that needed to know about the state outside of main.js.
- Make an object that creates the OSD viewer and returns it to main.js; make this object able to add event handlers that don't need to know about d3; there are probably some other things that could get moved into here, too.

I feel like this give us a clear path forward for factoring out the rest of OSD and d3. They don't touch each other that much anymore except in `synchroniseZoom()`, and, well, that has to happen _somewhere_!
